### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/X4.Black.Marketeer.Unlocker/security/code-scanning/1](https://github.com/BoBoBaSs84/X4.Black.Marketeer.Unlocker/security/code-scanning/1)

In general, the problem is fixed by adding an explicit `permissions` block to the workflow or individual jobs so that the `GITHUB_TOKEN` has only the minimal required scopes. For this particular CI job, the steps only need to read repository contents (for checkout); they do not push commits, create releases, or modify issues/PRs, so `contents: read` is sufficient.

The best minimal change is to add a workflow-level `permissions` block near the top of `.github/workflows/ci.yml`, after the `name:` (or before `jobs:`). This will apply to all jobs that do not define their own `permissions`. We will set:

```yaml
permissions:
  contents: read
```

No other functionality changes are needed, and no imports or extra methods are required since this is a YAML configuration file. Only `.github/workflows/ci.yml` needs to be edited, with the new block inserted after line 1 for clarity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
